### PR TITLE
Update operation sampling strategy

### DIFF
--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -53,8 +53,7 @@ struct SamplingStrategyResponse {
     1: required SamplingStrategyType strategyType
     2: optional ProbabilisticSamplingStrategy probabilisticSampling
     3: optional RateLimitingSamplingStrategy rateLimitingSampling
-    // 4 is deprecated
-    5: optional OperationSamplingStrategies operationSampling
+    4: optional OperationSamplingStrategies operationSampling
 }
 
 service SamplingManager {

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -53,6 +53,7 @@ struct SamplingStrategyResponse {
     1: required SamplingStrategyType strategyType
     2: optional ProbabilisticSamplingStrategy probabilisticSampling
     3: optional RateLimitingSamplingStrategy rateLimitingSampling
+    // 4 is deprecated
     5: optional OperationSamplingStrategies operationSampling
 }
 

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -39,7 +39,7 @@ struct RateLimitingSamplingStrategy {
 // the lower bound is met, operations are randomly sampled at a fixed percentage.
 struct OperationSamplingStrategies {
     1: required double defaultSamplingProbability
-    2: required double defaultLowerBound
+    2: required double defaultLowerBoundTracesPerSecond
     3: required list<OperationSamplingStrategy> strategies
 }
 

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -53,7 +53,7 @@ struct SamplingStrategyResponse {
     1: required SamplingStrategyType strategyType
     2: optional ProbabilisticSamplingStrategy probabilisticSampling
     3: optional RateLimitingSamplingStrategy rateLimitingSampling
-    4: optional OperationSamplingStrategies operationSampling
+    5: optional OperationSamplingStrategies operationSampling
 }
 
 service SamplingManager {

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -35,17 +35,25 @@ struct RateLimitingSamplingStrategy {
     1: required i16 maxTracesPerSecond
 }
 
-// OperationSamplingStrategy is the strategy used per operation.
+// OperationSamplingStrategies samples traces per operation with a guaranteed lower bound per second. Once
+// the lower bound is met, operations are randomly sampled at a fixed percentage.
+struct OperationSamplingStrategies {
+    1: required double defaultSamplingProbability
+    2: required double defaultLowerBound
+    3: required list<OperationSamplingStrategy> strategies
+}
+
+// OperationSamplingStrategy randomly samples a fixed percentage of operation traces.
 struct OperationSamplingStrategy {
-  1: required string operation
-  2: required ProbabilisticSamplingStrategy probabilisticSampling
+    1: required string operation
+    2: required ProbabilisticSamplingStrategy probabilisticSampling
 }
 
 struct SamplingStrategyResponse {
     1: required SamplingStrategyType strategyType
     2: optional ProbabilisticSamplingStrategy probabilisticSampling
     3: optional RateLimitingSamplingStrategy rateLimitingSampling
-    4: optional list<OperationSamplingStrategy> operationSamplingStrategies
+    4: optional OperationSamplingStrategies operationSampling
 }
 
 service SamplingManager {

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -35,15 +35,16 @@ struct RateLimitingSamplingStrategy {
     1: required i16 maxTracesPerSecond
 }
 
-// OperationSamplingStrategies samples traces per operation with a guaranteed lower bound per second. Once
-// the lower bound is met, operations are randomly sampled at a fixed percentage.
-struct OperationSamplingStrategies {
+// PerOperationSamplingStrategies defines a sampling strategy per each operation name in the service
+// with a guaranteed lower bound per second. Once the lower bound is met, operations are randomly sampled
+// at a fixed percentage.
+struct PerOperationSamplingStrategies {
     1: required double defaultSamplingProbability
     2: required double defaultLowerBoundTracesPerSecond
-    3: required list<OperationSamplingStrategy> strategies
+    3: required list<OperationSamplingStrategy> perOperationStrategies
 }
 
-// OperationSamplingStrategy randomly samples a fixed percentage of operation traces.
+// OperationSamplingStrategy defines a sampling strategy that randomly samples a fixed percentage of operation traces.
 struct OperationSamplingStrategy {
     1: required string operation
     2: required ProbabilisticSamplingStrategy probabilisticSampling
@@ -53,7 +54,7 @@ struct SamplingStrategyResponse {
     1: required SamplingStrategyType strategyType
     2: optional ProbabilisticSamplingStrategy probabilisticSampling
     3: optional RateLimitingSamplingStrategy rateLimitingSampling
-    4: optional OperationSamplingStrategies operationSampling
+    4: optional PerOperationSamplingStrategies operationSampling
 }
 
 service SamplingManager {


### PR DESCRIPTION
This is a breaking change, I might have to keep 4 as is and add 5 on SamplingStrategyResponse if someone has already deployed a client with the old change.