### PR TITLE
Revert "Use map instead of list for baggage restrictions"

### DIFF
--- a/thrift/baggage.thrift
+++ b/thrift/baggage.thrift
@@ -20,9 +20,11 @@
 
 namespace java com.uber.jaeger.thriftjava
 
-typedef string BaggageKey
-# MaxValueLength is the maximum length of the baggage value.
-typedef i32 MaxValueLength
+# BaggageRestriction contains the baggage key and the maximum length of the baggage value.
+struct BaggageRestriction {
+   1: required string baggageKey
+   2: required i32 maxValueLength
+}
 
 service BaggageRestrictionManager  {
     /**
@@ -30,5 +32,5 @@ service BaggageRestrictionManager  {
      * Usually, baggageRestrictions apply to all services however there may be situations
      * where a baggageKey might only be allowed to be set by a specific service.
      */
-    map<BaggageKey, MaxValueLength> getBaggageRestrictions(1: string serviceName)
+    list<BaggageRestriction> getBaggageRestrictions(1: string serviceName)
 }


### PR DESCRIPTION
Reverts uber/jaeger-idl#29

1) thrift language support for maps is weird, prefer wire format to be as simple as possible. 
2) the list is more efficient than map
3) struct is more easy to extend if we wanted to return more fields in baggage restrictions, with map it's a breaking change